### PR TITLE
clarify required format of project name in error logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ Toolkit.run(
       if (config.check_title) {
         // check the title matches [PROJECT-1234] somewhere
         if (!projects.some(project => title.match(createWrappedProjectRegex(project)))) {
-          tools.log('PR title ' + title + ' does not contain approved project')
+          tools.log('PR title ' + title + ' does not contain approved project with format [PROJECT-1234]')
           return false
         }
       }
@@ -50,7 +50,7 @@ Toolkit.run(
       // check the branch matches PROJECT-1234 or PROJECT_1234 somewhere
       if (config.check_branch) {
         if (!projects.some(project => head_branch.match(createProjectRegex(project)))) {
-          tools.log('PR branch ' + head_branch + ' does not contain an approved project')
+          tools.log('PR branch ' + head_branch + ' does not contain an approved project with format PROJECT-1234 or PROJECT_1234')
           return false
         }
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10469507/78279604-9d558780-74cc-11ea-85b8-f483e0d10761.png)
current error message in build log doesn't tell user the required project title format